### PR TITLE
Be more defensive about empty column checksums.

### DIFF
--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.1'
+__version__ = '0.7'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/super_csv/admin.py
+++ b/super_csv/admin.py
@@ -12,3 +12,4 @@ from .models import CSVOperation
 class OperationAdmin(admin.ModelAdmin):
     list_display = ('id', 'class_name', 'unique_id', 'created')
     readonly_fields = ('created', 'modified')
+    raw_id_fields = ('user', )

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -36,7 +36,7 @@ class ChecksumMixin(object):
     checksum_size = 4
 
     def _get_checksum(self, row):
-        to_check = ''.join(text_type(row[key] or '') for key in self.checksum_columns)
+        to_check = ''.join(text_type(row[key] if row[key] is not None else '') for key in self.checksum_columns)
         to_check += self.secret
         return '"%s"' % hashlib.md5(to_check.encode('utf8')).hexdigest()[:self.checksum_size]
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -105,6 +105,22 @@ class CSVTestCase(TestCase):
         with self.assertRaises(csv_processor.ValidationError):
             processor.validate_row(row)
 
+    def test_checksum_zero(self):
+        processor = DummyChecksumProcessor()
+        row = {
+            'foo': 0,
+            'bar': None,
+        }
+        processor.preprocess_export_row(row)
+        assert row['csum'] == '"fc43"'
+        assert processor.validate_row(row) is None
+        equiv_row = {
+            'foo': '0',
+            'bar': '',
+            'csum': '"fc43"'
+        }
+        assert processor.validate_row(equiv_row) is None
+
     def test_rollback(self):
         processor = DummyProcessor()
         processor.process_file(ContentFile(self.dummy_csv))


### PR DESCRIPTION
Previously, a column of None, 0, 0.0, or '' would all have the same checksum when exporting, but importing would fail because the string versions of those values result in different checksums.

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
