### PR TITLE
Serialize information we have about rows processed to history output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[0.7.1] - 2019-07-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Exposes additional fields in serialized history of operations re:degree of success of the operation
+
 [0.5.0] - 2019-07-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.7'
+__version__ = '0.7.1'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -114,7 +114,7 @@ class DeferrableMixin(object):
         """
         operation = CSVOperation.objects.get(pk=operation_id)
         log.info('Loading CSV state %s', operation.data.name)
-        state = json.loads(operation.data.read())
+        state = json.load(operation.data)
         module_name, classname = state.pop('__class__')
         if classname != cls.__name__:
             if not load_subclasses:

--- a/super_csv/serializers.py
+++ b/super_csv/serializers.py
@@ -3,26 +3,42 @@ Serializers for CSV operation data.
 """
 from __future__ import absolute_import, unicode_literals
 
+import json
+
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from .models import CSVOperation
 
 
+class CSVOperationDataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for data in CSV bulk operation summary results info
+    """
+    total_rows = serializers.IntegerField()
+    processed_rows = serializers.IntegerField()
+    saved_rows = serializers.IntegerField()
+
+
 class CSVOperationSerializer(serializers.ModelSerializer):
     """
-    Serializer for history CSV bulk grade operations
+    Serializer for CSV bulk operations
     """
 
     user = serializers.SlugRelatedField(
         slug_field='username',
         queryset=get_user_model().objects.all()
     )
+    data = serializers.SerializerMethodField()
 
     class Meta:
         model = CSVOperation
-        fields = ('class_name', 'unique_id', 'operation', 'user', 'modified', 'original_filename')
+        fields = ('id', 'class_name', 'unique_id', 'operation', 'user', 'modified', 'original_filename', 'data')
 
     @classmethod
     def get_related_queryset(cls, queryset):
         return queryset.select_related('user')
+
+    def get_data(self, operation):
+        data = json.load(operation.data)
+        return CSVOperationDataSerializer(data).data


### PR DESCRIPTION
JIRA:EDUCATOR-4435

**Description:** Serializes summary information tucked away inside files corresponding to each operation, for presentation of a summary while browsing the history of those operations

**JIRA:** https://openedx.atlassian.net/browse/EDUCATOR-4435

**Testing instructions:**

1. Load gradebook.
2. Search the network tab in Chrome dev tools for "history"
3. Note additional fields in each history entry returned

**Reviewers:**
- [ ] @davestgermain  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Concerned about the performance of this; I expect each time we serialize a row of history that'll add another round trip to S3 in production. We've talked about the next steps of paginating, but are moving forward considering that as out of scope. See https://openedx.atlassian.net/browse/EDUCATOR-4435?focusedCommentId=390272&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-390272