### PR TITLE
EDUCATOR-4638: pass along _user for when get_current_user() returns None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.2] - 2019-09-17
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* If a class inheriting from DeferrableMixin has a field _user, use that user for the CSVOperation if get_current_user is None
+* Pass CSVOperation user to DeferrableMixin constructor as `_user`
+
 [0.9.1] - 2019-07-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,7 @@ Unreleased
 [0.9.2] - 2019-09-17
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* If a class inheriting from DeferrableMixin has a field _user, use that user for the CSVOperation if get_current_user is None
-* Pass CSVOperation user to DeferrableMixin constructor as `_user`
+* If a class inheriting from DeferrableMixin has a field user_id, use that user for the CSVOperation
 
 [0.9.1] - 2019-07-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -81,6 +81,9 @@ class DeferrableMixin(object):
 
     Subclasses must override get_unique_path to uniquely identify
     this task
+
+    Subclasses can define a field `_user` which will be used when creating CSVOperations in `save`
+    and will be passed as a kwarg to the subclass's constructor when loading CSVOperations in `load`
     """
     # if the number of rows is greater than size_to_defer,
     # run the task asynchonously. Otherwise, commit immediately.

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -95,6 +95,7 @@ class DeferrableMixin(object):
         Save the state of this object to django storage.
         """
         state = self.__dict__.copy()
+        user = state.get('_user')
         for k, v in state.items():
             if k.startswith('_'):
                 del state[k]
@@ -108,7 +109,9 @@ class DeferrableMixin(object):
                         self.get_unique_path(),
                         op_name,
                         json.dumps(state),
-                        original_filename=state.get('filename', ''))
+                        original_filename=state.get('filename', ''),
+                        user=user,
+                    )
         return operation
 
     @classmethod
@@ -119,6 +122,7 @@ class DeferrableMixin(object):
         operation = CSVOperation.objects.get(pk=operation_id)
         log.info('Loading CSV state %s', operation.data.name)
         state = json.load(operation.data)
+        state['_user'] = operation.user
         module_name, classname = state.pop('__class__')
         if classname != cls.__name__:
             if not load_subclasses:

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -96,7 +96,9 @@ class DeferrableMixin(object):
         """
         state = self.__dict__.copy()
         user = state.get('_user')
-        for k, v in state.items():
+
+        for k in list(state):
+            v = state[k]
             if k.startswith('_'):
                 del state[k]
             elif isinstance(v, set):

--- a/super_csv/mixins.py
+++ b/super_csv/mixins.py
@@ -84,8 +84,8 @@ class DeferrableMixin(object):
     Subclasses must override get_unique_path to uniquely identify
     this task
 
-    Subclasses can define a field `_user` which will be used when creating CSVOperations in `save`
-    and will be passed as a kwarg to the subclass's constructor when loading CSVOperations in `load`
+    Subclasses can define a field `user_id` which will be loaded and saved in the CSVOperation.
+    Otherwise, the current request (if any) user will be used.
     """
     # if the number of rows is greater than size_to_defer,
     # run the task asynchonously. Otherwise, commit immediately.

--- a/super_csv/models.py
+++ b/super_csv/models.py
@@ -62,7 +62,7 @@ class CSVOperation(TimeStampedModel):
             return None
 
     @classmethod
-    def record_operation(cls, class_name_or_obj, unique_id, operation, data, original_filename=''):
+    def record_operation(cls, class_name_or_obj, unique_id, operation, data, original_filename='', user=None):
         """
         Save a CSVOperation
         """
@@ -70,7 +70,7 @@ class CSVOperation(TimeStampedModel):
                        unique_id=unique_id,
                        operation=operation,
                        original_filename=original_filename)
-        instance.user = get_current_user()
+        instance.user = user or get_current_user()
         # pylint: disable=no-member
         instance.data.save(uuid.uuid4(), ContentFile(data))
         return instance

--- a/super_csv/models.py
+++ b/super_csv/models.py
@@ -10,7 +10,6 @@ import uuid
 from datetime import timedelta
 
 import six
-from crum import get_current_user
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.db import models
@@ -66,11 +65,13 @@ class CSVOperation(TimeStampedModel):
         """
         Save a CSVOperation
         """
-        instance = cls(class_name=cls._get_class_name(class_name_or_obj),
-                       unique_id=unique_id,
-                       operation=operation,
-                       original_filename=original_filename)
-        instance.user = user or get_current_user()
+        instance = cls(
+            class_name=cls._get_class_name(class_name_or_obj),
+            unique_id=unique_id,
+            operation=operation,
+            original_filename=original_filename,
+            user=user,
+        )
         # pylint: disable=no-member
         instance.data.save(uuid.uuid4(), ContentFile(data))
         return instance

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -157,7 +157,7 @@ class CSVTestCase(TestCase):
         operation = models.CSVOperation.get_latest(processor, processor.get_unique_path())
         assert operation is not None
 
-    @mock.patch('super_csv.models.get_current_user')
+    @mock.patch('super_csv.mixins.get_current_user')
     def test_user(self, patch_get_user):
         user = get_user_model().objects.create_user(username='testuser', password='12345')
         buf = ContentFile(self.dummy_csv)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -168,6 +168,5 @@ class CSVTestCase(TestCase):
         processor.process_file(buf)
         csv_operations = models.CSVOperation.objects.all()
         assert len(csv_operations) == 3
-        assert csv_operations[0].user == user
-        assert csv_operations[1].user is None
-        assert csv_operations[2].user is None
+        for csv_operation in csv_operations:
+            assert csv_operation.user == user

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -4,14 +4,13 @@ Tests for CSVProcessor
 from __future__ import absolute_import, print_function, unicode_literals
 
 import io
-import mock
 
 import ddt
+import mock
+from django.contrib.auth import get_user_model
 # could use BytesIO, but this adds a size attribute
 from django.core.files.base import ContentFile
 from django.test import TestCase
-from django.contrib.auth import get_user_model
-
 
 from super_csv import csv_processor, models
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -163,7 +163,7 @@ class CSVTestCase(TestCase):
         buf = ContentFile(self.dummy_csv)
         processor = DummyDeferrableProcessor()
         patch_get_user.side_effect = (user, None, None)
-        processor._user = user
+        processor.user_id = user.id
         processor.process_file(buf)
         csv_operations = models.CSVOperation.objects.all()
         assert len(csv_operations) == 3


### PR DESCRIPTION
**Description:** When a `DeferrableMIxin` is saved, the dict state of the object is iterated through, removing any `_private` fields so that the state can be saved as json when we create a CSVOperation. We then call `get_current_user()` to get the user to associate with the CSVOperation.  

However, in certain contexts - like within a celery task, where we've lost the context of the request -`get_current_user()` will return None. 

This is an issue in two places:

1) when we call `get_committed_history()` - the 'commit' CSVOperations may not have a user set, which we may want for auditing who did what

2) the implementing class that is inheriting from `DeferrableMixin` may need that user information when we are calling process_row (for example, when we are doing bulk grade import, the `GradeCSVProcessor` that inherits from `DeferrableMixin` needs the user to pass along for for further downstream history recording.)

**What does this PR do:** When a `DeferrableMixin` is saved, check if the state has a `user_id` field. If there is, load the user and use that user as the CSVOperation user. Otherwise, use `get_current_user`. 

This should allow us to persist the user in CSVOperations if we lose the request context

**JIRA:** [EDUCATOR-4638](https://openedx.atlassian.net/browse/EDUCATOR-4638)

**Reviewers:**
@edx/masters-devs 
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
