### PR TITLE
Do a DB commit for CSVOperation before enqueueing a task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ tests/__init__.py
 
 # Development task artifacts
 default.db
+
+# local virtualenvs
+supercsv-env/
+
+# test output
+csv/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.3] - 2019-09-20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Commit after ``CSVOperation`` creation so that async celery tasks can find the operation record when they start.
+
 [0.9.2] - 2019-09-17
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,3 +6,4 @@ django-model-utils         # Provides TimeStampedModel abstract base class
 django-celery
 django-crum
 djangorestframework
+edx-celeryutils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,5 +13,6 @@ django-crum==0.7.3
 django-model-utils==3.2.0
 django==1.11.23
 djangorestframework==3.9.4
+edx-celeryutils==0.3.0
 kombu==3.0.37             # via celery
 pytz==2019.2              # via celery, django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,6 +31,7 @@ django-crum==0.7.3
 django-model-utils==3.2.0
 django==1.11.23
 djangorestframework==3.9.4
+edx-celeryutils==0.3.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 enum34==1.1.6

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 click==7.0                # via pip-tools
-pip-tools==4.0.0
+pip-tools==4.1.0
 six==1.12.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,6 +29,7 @@ django-crum==0.7.3
 django-model-utils==3.2.0
 django==1.11.23
 djangorestframework==3.9.4
+edx-celeryutils==0.3.0
 edx-lint==1.3.0
 enum34==1.1.6             # via astroid
 freezegun==0.3.12

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,6 +20,7 @@ django-celery==3.3.0
 django-crum==0.7.3
 django-model-utils==3.2.0
 djangorestframework==3.9.4
+edx-celeryutils==0.3.0
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock, pytest
 importlib-metadata==0.19  # via pluggy, pytest

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This is meant to address the issue we've seen in stage/prod (where celery tasks are actually run in a different process/transaction) where the `do_deferred_commit` celery task fails because it's looking for a `CSVOperation` that hasn't yet been committed to the database.  Timeline of events looks like this:

1. Request is made to process a CSV.  This opens DB transaction A.
2. We process the CSV and "stage" some grade override data to be written.
3. We call `commit()`, which first writes a `CSVOperation` record with id=X.  We're still in transaction A.
4. `commit()` then enqueues a celery task to write the data.
5. The celery task starts and opens transaction B.  Within this task/transaction, we try to 
read a `CSVOperation` with id=X.  <-- transaction A hasn't committed yet, so the read fails.
6. The task errors out.
7. transaction A (from the request) is committed.

The change this PR makes is to force a DB commit at the end of step (3), so that the `CSVOperation` with id=X will exist for all future database transactions.