### PR TITLE
EDUCATOR-4638 | Add operating_user kwargs to DeferrableMixin.save()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.4] - 2019-09-24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Let the ``DeferrableMixin.save()`` method take an optional ``operating_user`` parameter.
+
 [0.9.3] - 2019-09-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,8 +6,6 @@ Tests for the `super-csv` models module.
 
 from __future__ import absolute_import, unicode_literals
 
-from datetime import datetime, timedelta
-
 from django.conf import settings
 from django.test import TestCase
 from mock import patch


### PR DESCRIPTION
**Description:**
This PR is 1 of 2 (forthcoming edx-bulk-grades PR).  It attempts to clean up with interface around saving a user associated with a ``CSVOperation`` by introducing an optional ``operating_user`` kwargs to ``DeferrableMixin.save()``.  This allows subclasses to override that method and pass in an associated user in any way that they see fit.

**JIRA:**
https://openedx.atlassian.net/browse/EDUCATOR-4638

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
