### PR TITLE
decode input before reading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.5] - 2019-10-08
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Decode the input file before passing to DictReader if necessary
+
 [0.9.4] - 2019-09-24
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -4,6 +4,6 @@ CSV Processor.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/super_csv/csv_processor.py
+++ b/super_csv/csv_processor.py
@@ -96,6 +96,15 @@ class Echo(object):
         return value
 
 
+def decode_utf8(input_iterator):
+    """
+    Generator that decodes a utf-8 encoded
+    input line by line
+    """
+    for l in input_iterator:
+        yield l if isinstance(l, str) else l.decode('utf-8')
+
+
 class CSVProcessor(object):
     """
     Generic CSV processor.
@@ -188,7 +197,7 @@ class CSVProcessor(object):
         """
         try:
             self.filename = getattr(thefile, 'name', '') or ''
-            reader = csv.DictReader(thefile)
+            reader = csv.DictReader(decode_utf8(thefile))
             self.validate_file(thefile, reader)
             return reader
         except ValidationError as exc:


### PR DESCRIPTION
**Description:** When writing tests for https://github.com/edx/edx-bulk-grades/pull/37 , I found the following: in python 3, the django request.FILES dictionary returns objects that when iterated over, return bytes rather than strings. We need to decode the bytes before passing them to the CSV DictReader

**JIRA:** [EDUCATOR-4643](https://openedx.atlassian.net/browse/EDUCATOR-4643)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
