### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,4 +22,4 @@ class TestModel(TestCase):
             operation.id = 3
             operation.save()
         operation = CSVOperation.objects.get(pk=operation_id)
-        assert operation.data.name is ''
+        assert operation.data.name == ''


### PR DESCRIPTION
**Description:** Fixes syntax warnings. Closes #26 

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
