### PR TITLE
Pin importlib-metadata and run make upgrade

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,3 +16,6 @@ django < 2.3
 
 
 celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.
+
+# Needed as long as tox constrains this to <2
+importlib-metadata<2


### PR DESCRIPTION
**Description:** 

https://build.testeng.edx.org/job/super-csv-upgrade-python-requirements/5/

The above build failed because we couldn't resolve versions of importlib-metadata
Added a constraint on importlib-metadata