### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.0.3] - 2020-11-20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Updated travis badge in README.rst to point to travis-ci.com
+
 [1.0.2] - 2020-09-14
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Move to Apache License

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/super-csv/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/super-csv.svg?branch=master
-    :target: https://travis-ci.org/edx/super-csv
+.. |travis-badge| image:: https://travis-ci.com/edx/super-csv.svg?branch=master
+    :target: https://travis-ci.com/edx/super-csv
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/super-csv/coverage.svg?branch=master

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -2,6 +2,6 @@
 CSV Processor.
 """
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Travis badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089