### PR TITLE
fix: gradebook history not rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,12 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
-~~~~~~~~~~
+----------
+
+[2.1.1] - 2021-09-01
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix missing file error for bulk grade. Some of the files were expired but the code still expect to read it without `try/catch`.
 
 [2.1.0] - 2020-07-26
 ~~~~~~~~~~~~~~~~~~~~

--- a/super_csv/__init__.py
+++ b/super_csv/__init__.py
@@ -2,6 +2,6 @@
 CSV Processor.
 """
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 default_app_config = 'super_csv.apps.SuperCSVConfig'  # pylint: disable=invalid-name

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+Tests for the `super-csv` mixins module.
+"""
+
+import json
+
+from django.test import TestCase
+
+from super_csv.serializers import CSVOperation, CSVOperationSerializer
+
+
+class SerializerTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.data = {
+            "total_rows": 3,
+            "processed_rows": 4,
+            "saved_rows": 5
+        }
+
+        self.operation = CSVOperation.record_operation('some_name', 'course_id', 'save', json.dumps(self.data))
+
+    def tearDown(self):
+        super().tearDown()
+        CSVOperation.expire_data(-1)
+
+    def test_get_data_success(self):
+        # Test success get total_rows
+        operation_serializer = CSVOperationSerializer(self.operation)
+        data = operation_serializer.data
+
+        operation_data = data['data']
+
+        self.assertDictEqual(operation_data, self.data)
+        self.assertNotIn('error_message', operation_data)
+
+    def test_get_data_fail(self):
+        # test error
+        CSVOperation.expire_data(-1)
+        operation_serializer = CSVOperationSerializer(self.operation)
+        data = operation_serializer.data
+
+        operation_data = data['data']
+
+        self.assertEqual(operation_data['total_rows'], 0)
+        self.assertEqual(operation_data['processed_rows'], 0)
+        self.assertEqual(operation_data['saved_rows'], 0)
+        self.assertIn('error_message', operation_data)


### PR DESCRIPTION
Some of the courses experienced bulk management csv import history not showing up.

https://openedx.atlassian.net/browse/AU-12

**Testing instructions:**

Reproduce:
1. Connect to mysql
2. Query `SELECT * FROM edxapp.super_csv_csvoperation where class_name = 'bulk_grades.api.GradeCSVProcessor' AND unique_id = 'course-v1:edX+DemoX+Demo_Course';`
3. Change the course id to the desire course id you want to test
4. Modify some of the `data` field to be incorrect
5. Bulk management import history will stop rendering

<img width="1652" alt="Screen Shot 2021-07-09 at 2 32 48 PM" src="https://user-images.githubusercontent.com/83240113/125121968-baf7a080-e0c2-11eb-9c4d-446c802ffd45.png">
After:
<img width="1660" alt="Screen Shot 2021-07-09 at 2 33 35 PM" src="https://user-images.githubusercontent.com/83240113/125122026-d2cf2480-e0c2-11eb-8d18-1ce4f3c0a0fa.png">

Currently, it will only show `0 Students, 0 processed` until I get to change the frontend's logic change/approval design.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
