### PR TITLE
chore: make sure preprocess_row include row number

### DIFF
--- a/super_csv/csv_processor.py
+++ b/super_csv/csv_processor.py
@@ -218,7 +218,7 @@ class CSVProcessor:
             result = ResultDict(row)
             try:
                 self.validate_row(row)
-                row = self.preprocess_row(row)
+                row = self.preprocess_row(row, rownum)
                 if row:
                     self.stage.append((rownum, row))
                     processed_rows += 1
@@ -260,7 +260,7 @@ class CSVProcessor:
         Returns a row.
         """
 
-    def preprocess_row(self, row):
+    def preprocess_row(self, row, rownum):
         """
         Preprocess the row.
         Returns the same row or new row, or None.

--- a/super_csv/csv_processor.py
+++ b/super_csv/csv_processor.py
@@ -211,14 +211,14 @@ class CSVProcessor:
         Preprocess the rows, saving them to the staging list.
         """
         rownum = processed_rows = 0
-        snapshot = []
         failure = _('Failure')
         no_action = _('No Action')
+        self.result_data = []
         for rownum, row in enumerate(reader, 1):
             result = ResultDict(row)
             try:
                 self.validate_row(row)
-                row = self.preprocess_row(row, rownum)
+                row = self.preprocess_row(row)
                 if row:
                     self.stage.append((rownum, row))
                     processed_rows += 1
@@ -228,8 +228,7 @@ class CSVProcessor:
                 self.add_error(str(e), rownum)
                 result['error'] = str(e)
                 result['status'] = failure
-            snapshot.append(result)
-        self.result_data = snapshot
+            self.result_data.append(result)
         self.total_rows = rownum
         self.processed_rows = processed_rows
 
@@ -260,7 +259,7 @@ class CSVProcessor:
         Returns a row.
         """
 
-    def preprocess_row(self, row, rownum):
+    def preprocess_row(self, row):
         """
         Preprocess the row.
         Returns the same row or new row, or None.


### PR DESCRIPTION
**Description:** make sure preprocess_row include row number. It is necessary for detecting duplicate user_id on the first occurence.

**JIRA:** [AU-44](https://openedx.atlassian.net/browse/AU-44)

**Testing instructions:**

- [ ] Pass `make test`

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Merge and release this before upgrade this [https://github.com/edx/edx-bulk-grades/pull/88](https://github.com/edx/edx-bulk-grades/pull/88)

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.

@edx/masters-devs-gta 