### PR TITLE
fix: replace travis.txt with ci.txt in dev requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ----------
 
+* Fix `dev.in` to pull from `ci.txt` rather than `travis.txt`.
+
 [2.1.1] - 2021-09-01
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,7 +3,7 @@
 
 -r pip-tools.txt          # pip-tools and its dependencies, for managing requirements files
 -r quality.txt            # Core and quality check dependencies
--r travis.txt             # tox and related dependencies
+-r ci.txt                 # tox and related dependencies
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy


### PR DESCRIPTION
**Description:**  `make upgrade` was failing as `dev.in` was still referencing `travis.txt`, which no longer exists.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [x] Delete working branch (if not needed anymore)
